### PR TITLE
Change the default value of optional parameter sub

### DIFF
--- a/lib/bamboo/adapters/sendcloud_helper.ex
+++ b/lib/bamboo/adapters/sendcloud_helper.ex
@@ -5,7 +5,7 @@ defmodule Bamboo.SendcloudHelper do
 
   alias Bamboo.Email
 
-  def template(email, template_name, sub \\ []) do
+  def template(email, template_name, sub \\ %{}) do
     email
     |> Email.put_private(:template_name, template_name)
     |> Email.put_private(:sub, sub)

--- a/test/lib/sendcloud_adapter_test.exs
+++ b/test/lib/sendcloud_adapter_test.exs
@@ -25,7 +25,7 @@ defmodule Bamboo.SendcloudAdapterTest do
         email
         |> SendcloudAdapter.deliver(@config)
 
-      assert {:ok, info} = result
+      assert {:ok, _info} = result
     end
   end
 
@@ -39,7 +39,7 @@ defmodule Bamboo.SendcloudAdapterTest do
         email
         |> SendcloudAdapter.deliver(@config)
 
-      assert {:ok, info} = result
+      assert {:ok, _info} = result
     end
   end
 

--- a/test/lib/sendcloud_helper_test.exs
+++ b/test/lib/sendcloud_helper_test.exs
@@ -5,10 +5,10 @@ defmodule Bamboo.SendcloudAdapter.HelperTest do
   alias Bamboo.SendcloudHelper
 
   test "adds template information to emails" do
-    email = new_email() |> SendcloudHelper.template("test_template_active", [%{"name" => "example_name", "content" => "example_content"}])
-    assert email.private == %{template_name: "test_template_active", sub: [%{"name" => "example_name", "content" => "example_content"}]}
+    email = new_email() |> SendcloudHelper.template("test_template_active", %{"name" => ["example_name"], "content" => ["example_content"]})
+    assert email.private == %{template_name: "test_template_active", sub: %{"name" => ["example_name"], "content" => ["example_content"]}}
 
     email = new_email() |> SendcloudHelper.template("test_template_active")
-    assert email.private == %{template_name: "test_template_active", sub: []}
+    assert email.private == %{template_name: "test_template_active", sub: %{}}
   end
 end


### PR DESCRIPTION
When I use `Bamboo.SendcloudHelper.template` function but didn't pass optional parameter `sub`, I got an error: other functions expects the type of parameter `sub` to be Map.
